### PR TITLE
XcRegions: fix remove

### DIFF
--- a/contracts/xc-regions/src/lib.rs
+++ b/contracts/xc-regions/src/lib.rs
@@ -212,6 +212,7 @@ pub mod xc_regions {
 			let owner =
 				psp34::PSP34Impl::owner_of(self, id.clone()).ok_or(XcRegionsError::CannotRemove)?;
 
+			ensure!(owner == self.env().caller(), XcRegionsError::CannotRemove);
 			self.regions.remove(region_id);
 
 			psp34::InternalImpl::_burn_from(self, owner, id).map_err(XcRegionsError::Psp34)?;

--- a/contracts/xc-regions/src/lib.rs
+++ b/contracts/xc-regions/src/lib.rs
@@ -207,7 +207,7 @@ pub mod xc_regions {
 		/// ## Events:
 		/// On success this ink message emits the `RegionRemoved` event.
 		#[ink(message)]
-		fn(&mut self, region_id: RawRegionId) -> Result<(), XcRegionsError> {
+		fn remove(&mut self, region_id: RawRegionId) -> Result<(), XcRegionsError> {
 			let id = Id::U128(region_id);
 			let owner =
 				psp34::PSP34Impl::owner_of(self, id.clone()).ok_or(XcRegionsError::CannotRemove)?;

--- a/contracts/xc-regions/src/lib.rs
+++ b/contracts/xc-regions/src/lib.rs
@@ -199,7 +199,7 @@ pub mod xc_regions {
 		/// This process involves burning the wrapped region and eliminating its associated
 		/// metadata.
 		///
-		///Only the owner of the wrapped region can call this function.
+		/// Only the owner of the wrapped region can call this function.
 		///
 		/// ## Arguments:
 		/// - `raw_region_id` - The `u128` encoded region identifier.
@@ -207,7 +207,7 @@ pub mod xc_regions {
 		/// ## Events:
 		/// On success this ink message emits the `RegionRemoved` event.
 		#[ink(message)]
-		fn remove(&mut self, region_id: RawRegionId) -> Result<(), XcRegionsError> {
+		fn(&mut self, region_id: RawRegionId) -> Result<(), XcRegionsError> {
 			let id = Id::U128(region_id);
 			let owner =
 				psp34::PSP34Impl::owner_of(self, id.clone()).ok_or(XcRegionsError::CannotRemove)?;

--- a/contracts/xc-regions/src/tests.rs
+++ b/contracts/xc-regions/src/tests.rs
@@ -120,7 +120,7 @@ fn init_works() {
 
 #[ink::test]
 fn remove_works() {
-	let DefaultAccounts::<DefaultEnvironment> { charlie, .. } = get_default_accounts();
+	let DefaultAccounts::<DefaultEnvironment> { bob, charlie, .. } = get_default_accounts();
 	let mut xc_regions = XcRegions::new();
 	set_caller::<DefaultEnvironment>(charlie);
 
@@ -143,6 +143,11 @@ fn remove_works() {
 	assert_eq!(xc_regions.regions.get(0), Some(Region::default()));
 	assert_eq!(xc_regions.metadata_versions.get(0), Some(0));
 
+	// Only charlie can remove the region:
+	set_caller::<DefaultEnvironment>(bob);
+	assert_eq!(xc_regions.remove(0), Err(XcRegionsError::CannotRemove));
+
+	set_caller::<DefaultEnvironment>(charlie);
 	// Removing a region works:
 	assert_ok!(xc_regions.remove(0));
 


### PR DESCRIPTION
As the documentation for the remove function states, only the region owner should be able to remove the region.
